### PR TITLE
Added a get all endpoint for admins

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -68,7 +68,7 @@ public class RecommendationRequestController extends ApiController {
      * 
      * @return a message indicating that the RecommendationRequest was deleted
      */
-    @Operation(summary = "An admin can delete a RecommendationRequest")
+    @Operation(summary = "An admin can get all RecommendationRequests")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin/all")
     public Object getRecommendationRequestsAsAdmin() {

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -66,7 +66,6 @@ public class RecommendationRequestController extends ApiController {
     /**
      * Any admin can get all RecommendationRequests
      * 
-     * @param id the id of the RecommendationRequest to delete
      * @return a message indicating that the RecommendationRequest was deleted
      */
     @Operation(summary = "An admin can delete a RecommendationRequest")
@@ -79,6 +78,7 @@ public class RecommendationRequestController extends ApiController {
     /**
      * The user who posted a RecommendationRequest can delete their RecommendationRequest
      * 
+     * @param id the id of the RecommendationRequest to delete
      * @return a message indicating that the RecommendationRequest was deleted
      */
     @Operation(summary = "User can delete their RecommendationRequest")

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -64,6 +64,19 @@ public class RecommendationRequestController extends ApiController {
     }
 
     /**
+     * Any admin can get all RecommendationRequests
+     * 
+     * @param id the id of the RecommendationRequest to delete
+     * @return a message indicating that the RecommendationRequest was deleted
+     */
+    @Operation(summary = "An admin can delete a RecommendationRequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin/all")
+    public Object getRecommendationRequestsAsAdmin() {
+        return recommendationRequestRepository.findAll();
+    }
+
+    /**
      * The user who posted a RecommendationRequest can delete their RecommendationRequest
      * 
      * @param id the id of the RecommendationRequest to delete

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -79,7 +79,6 @@ public class RecommendationRequestController extends ApiController {
     /**
      * The user who posted a RecommendationRequest can delete their RecommendationRequest
      * 
-     * @param id the id of the RecommendationRequest to delete
      * @return a message indicating that the RecommendationRequest was deleted
      */
     @Operation(summary = "User can delete their RecommendationRequest")

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -232,6 +232,55 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
 
     }
 
+    //Admin can delete a recommendation request
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_get_all_recommendation_requests() throws Exception {
+        // arrange
+
+        User user2 = User.builder().id(44).build(); 
+        User prof = User.builder()
+                .id(22L)
+                .email("profA@ucsb.edu")
+                .googleSub("googleSub")
+                .fullName("Prof A")
+                .givenName("Prof")
+                .familyName("A")
+                .emailVerified(true)
+                .professor(true)
+                .build();
+
+        RecommendationRequest rec1 = RecommendationRequest.builder()
+                .id(67L)
+                .requester(user2)
+                .professor(prof)
+                .recommendationType("PhDprogram")
+                .details("details")
+                .status("PENDING")
+                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .build();
+
+        ArrayList<RecommendationRequest> allRequests = new ArrayList<>();
+        allRequests.add(rec1);
+
+        when(recommendationRequestRepository.findAll()).thenReturn(allRequests);
+        // act
+        MvcResult response = mockMvc.perform(
+                get("/api/recommendationrequest/admin/all")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(recommendationRequestRepository, times(1)).findAll();
+        
+        String expected = mapper.writeValueAsString(allRequests);
+        String actual = response.getResponse().getContentAsString();
+        assertEquals(expected, actual);
+    }
+
     //Admin can't delete a recommendation request that dne
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -232,7 +232,7 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
 
     }
 
-    //Admin can delete a recommendation request
+    //Admin can get all recommendation requests
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void admin_can_get_all_recommendation_requests() throws Exception {


### PR DESCRIPTION
Closes #40 

In this pull request, I added a get all endpoint for admin users. 

Screenshot: 
![image](https://github.com/user-attachments/assets/0c52db01-27c8-41b0-8de0-73b8e6ba2e7e)

To test:
1. visit https://proj-rec-tyler-w0ng.dokku-15.cs.ucsb.edu/
2. Go to swagger
3. Test endpoint shown in screenshot