### PR TITLE
Student role defaults to true for new users.

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -37,7 +37,7 @@ public class User {
   @Builder.Default
   private Boolean admin=false;
   @Builder.Default
-  private Boolean student=false;
+  private Boolean student=true;
   @Builder.Default
   private Boolean professor=false;
 }


### PR DESCRIPTION
When a new user logs in, the student role defaults to true instead of false.

Testing instructions:
Run on localhost or dokku:
- clean the database
- login as an admin, go to swagger, and check that you have the student role.

Closes issue #21 